### PR TITLE
Enable revocation when easyrsa version 3.0 is used

### DIFF
--- a/manifests/revoke.pp
+++ b/manifests/revoke.pp
@@ -25,10 +25,29 @@ define openvpn::revoke (
 
   $etc_directory = $openvpn::etc_directory
 
+  $revocation_command = $openvpn::easyrsa_version ? {
+    '2.0' => ". ./vars && ./revoke-full ${name}; echo \"exit $?\" | grep -qE '(error 23|exit (0|2))' && touch revoked/${name}",
+    '3.0' => ". ./vars && ./easyrsa revoke --batch ${name}; echo \"exit $?\" | grep -qE '(error 23|exit (0|2))' && touch revoked/${name}",
+  }
+
+  $renew_command = $openvpn::easyrsa_version ? {
+    '2.0'   => ". ./vars && KEY_CN='' KEY_OU='' KEY_NAME='' KEY_ALTNAMES='' openssl ca -gencrl -out ${openvpn::etc_directory}/openvpn/${name}/crl.pem -config ${openvpn::etc_directory}/openvpn/${name}/easy-rsa/openssl.cnf",
+    '3.0'   => ". ./vars && EASYRSA_REQ_CN='' EASYRSA_REQ_OU='' openssl ca -gencrl -out ${etc_directory}/openvpn/${name}/crl.pem -config ${etc_directory}/openvpn/${name}/easy-rsa/openssl.cnf",
+    default => fail("unexepected value for EasyRSA version, got '${openvpn::easyrsa_version}', expect 2.0 or 3.0."),
+  }
+
   exec { "revoke certificate for ${name} in context of ${server}":
-    command  => ". ./vars && ./revoke-full ${name}; echo \"exit $?\" | grep -qE '(error 23|exit (0|2))' && touch revoked/${name}",
+    command  => $revocation_command,
     cwd      => "${etc_directory}/openvpn/${server}/easy-rsa",
     creates  => "${etc_directory}/openvpn/${server}/easy-rsa/revoked/${name}",
     provider => 'shell',
+    notify   => Exec["renew crl.pem on ${name}"],
+  }
+
+  exec { "renew crl.pem on ${name}":
+    command  => $renew_command,
+    cwd      => "${openvpn::etc_directory}/openvpn/${name}/easy-rsa",
+    provider => 'shell',
+    schedule => "renew crl.pem schedule on ${name}",
   }
 }

--- a/spec/defines/openvpn_client_spec.rb
+++ b/spec/defines/openvpn_client_spec.rb
@@ -69,7 +69,10 @@ describe 'openvpn::client', type: :define do
       }
 
       context 'setting the minimum parameters' do
-        let(:params) { { 'server' => 'test_server' } }
+        let(:params) { {
+          'server'      => 'test_server',
+          'remote_host' => 'foo.example.com',
+        } }
 
         it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^client$}) }
         it { is_expected.to contain_file('/etc/openvpn/test_server/download-configs/test_client/test_client.conf').with_content(%r{^ca\s+keys/test_client/ca\.crt$}) }

--- a/spec/defines/openvpn_revoke_spec.rb
+++ b/spec/defines/openvpn_revoke_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'openvpn::revoke', type: :define do
   on_supported_os.each do |os, facts|
-    context "on #{os}" do
+    context "on #{os} with easyrsa version 2.0" do
       let(:pre_condition) do
         [
           'openvpn::server { "test_server":
@@ -18,7 +18,9 @@ describe 'openvpn::revoke', type: :define do
         ].join
       end
       let(:facts) do
-        facts
+        facts.merge(
+          easyrsa: '2.0'
+        )
       end
       let(:title) { 'test_client' }
       let(:params) { { 'server' => 'test_server' } }
@@ -28,6 +30,37 @@ describe 'openvpn::revoke', type: :define do
       it {
         is_expected.to contain_exec('revoke certificate for test_client in context of test_server').with(
           'command' => ". ./vars && ./revoke-full test_client; echo \"exit $?\" | grep -qE '(error 23|exit (0|2))' && touch revoked/test_client"
+        )
+      }
+    end
+    context "on #{os} with easyrsa version 3.0" do
+      let(:pre_condition) do
+        [
+          'openvpn::server { "test_server":
+            country       => "CO",
+            province      => "ST",
+            city          => "Some City",
+            organization  => "example.org",
+            email         => "testemail@example.org"
+          }',
+          'openvpn::client { "test_client3":
+            server => "test_server"
+          }'
+        ].join
+      end
+      let(:facts) do
+        facts.merge(
+          easyrsa: '3.0'
+        )
+      end
+      let(:title) { 'test_client3' }
+      let(:params) { { 'server' => 'test_server' } }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it {
+        is_expected.to contain_exec('revoke certificate for test_client3 in context of test_server').with(
+          'command' => ". ./vars && ./easyrsa revoke --batch test_client3; echo \"exit $?\" | grep -qE '(error 23|exit (0|2))' && touch revoked/test_client3"
         )
       }
     end


### PR DESCRIPTION
#### Pull Request (PR) description
This change makes it possible to revoke certificates when easyrsa version 3.x is used. There currently is an open PR open for this issue, however this has not had an update since March 2019, therefore I am opening this PR. See: #338 

The `remote_host` parameter is set, because the expected value of
`foo.example.com` is not evaluated correctly on ArchLinux.

#### This Pull Request (PR) fixes the following issues
Fixes #331 
